### PR TITLE
Fix a double-free

### DIFF
--- a/Framework/MobileDevice/SDMMD_Functions.h
+++ b/Framework/MobileDevice/SDMMD_Functions.h
@@ -705,8 +705,6 @@ ATR_UNUSED static CFMutableDictionaryRef SDMMD__CreatePairingMaterial(CFDataRef 
 	Safe(X509_free,rootX509);
 	Safe(X509_free,hostX509);
 	Safe(X509_free,deviceX509);
-	Safe(RSA_free,rootKeyPair);
-	Safe(RSA_free,hostKeyPair);
 	
     return record;
 }


### PR DESCRIPTION
Fix a double-free that can occur because memory ownership of rootKeyPair and hostKeyPair and transferred to the rootEVP and hostEVP structures by EVP_PKEY_assign().
