### PR TITLE
Project/Framework cleanups

### DIFF
--- a/iOSConsole/iOSConsole/apps.c
+++ b/iOSConsole/iOSConsole/apps.c
@@ -10,10 +10,10 @@
 #define iOSConsole_apps_c
 
 #include "apps.h"
-#include "SDMMobileDevice.h"
+#include <SDMMobileDevice/SDMMobileDevice.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include "attach.h"
-#include "Core.h"
+#include <SDMMobileDevice/Core.h>
 
 void LookupAppsOnDevice(char *udid) {
 	SDMMD_AMDeviceRef device = FindDeviceFromUDID(udid);

--- a/iOSConsole/iOSConsole/attach.c
+++ b/iOSConsole/iOSConsole/attach.c
@@ -10,7 +10,7 @@
 #define iOSConsole_attach_c
 
 #include "attach.h"
-#include "Core.h"
+#include <SDMMobileDevice/Core.h>
 
 SDMMD_AMDeviceRef FindDeviceFromUDID(char *udid) {
 	CFArrayRef devices = SDMMD_AMDCreateDeviceList();

--- a/iOSConsole/iOSConsole/attach.h
+++ b/iOSConsole/iOSConsole/attach.h
@@ -10,7 +10,7 @@
 #define iOSConsole_attach_h
 
 #include <CoreFoundation/CoreFoundation.h>
-#include "SDMMobileDevice.h"
+#include <SDMMobileDevice/SDMMobileDevice.h>
 
 SDMMD_AMDeviceRef FindDeviceFromUDID(char *udid);
 SDMMD_AMConnectionRef AttachToDeviceAndService(SDMMD_AMDeviceRef device, char *service);

--- a/iOSConsole/iOSConsole/list.c
+++ b/iOSConsole/iOSConsole/list.c
@@ -11,8 +11,8 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 
-#include "SDMMobileDevice.h"
-#include "Core.h"
+#include <SDMMobileDevice/SDMMobileDevice.h>
+#include <SDMMobileDevice/Core.h>
 
 #include "list.h"
 

--- a/iOSConsole/iOSConsole/main.c
+++ b/iOSConsole/iOSConsole/main.c
@@ -9,8 +9,8 @@
 #include <getopt.h>
 #include <CoreFoundation/CoreFoundation.h>
 
-#include "SDMMobileDevice.h"
-#include "Core.h"
+#include <SDMMobileDevice/SDMMobileDevice.h>
+#include <SDMMobileDevice/Core.h>
 
 #include "Features.h"
 

--- a/iOSConsole/iOSConsole/power.c
+++ b/iOSConsole/iOSConsole/power.c
@@ -10,7 +10,7 @@
 #define iOSConsole_power_c
 
 #include "power.h"
-#include "Core.h"
+#include <SDMMobileDevice/Core.h>
 #include "attach.h"
 #include "SDMMobileDevice.h"
 #include "SDMMD_Service.h"

--- a/iOSConsole/iOSConsole/query.c
+++ b/iOSConsole/iOSConsole/query.c
@@ -11,8 +11,8 @@
 
 #include "query.h"
 #include "attach.h"
-#include "Core.h"
-#include "SDMMobileDevice.h"
+#include <SDMMobileDevice/Core.h>
+#include <SDMMobileDevice/SDMMobileDevice.h>
 
 void RunQueryOnDevice(SDMMD_AMDeviceRef device, char *domain, char *key, sdmmd_return_t result) {
 	if (SDM_MD_CallSuccessful(result)) {

--- a/iOSConsole/iOSConsole/run.c
+++ b/iOSConsole/iOSConsole/run.c
@@ -13,7 +13,7 @@
 #include "apps.h"
 #include "attach.h"
 #include <CoreFoundation/CoreFoundation.h>
-#include "SDMMobileDevice.h"
+#include <SDMMobileDevice/SDMMobileDevice.h>
 
 void RunAppOnDeviceWithIdentifier(char *udid, char* identifier) {
 	SDMMD_AMDeviceRef device = FindDeviceFromUDID(udid);

--- a/iOSConsole/iOSConsole/springboard.h
+++ b/iOSConsole/iOSConsole/springboard.h
@@ -10,7 +10,7 @@
 #define iOSConsole_springboard_h
 
 #include <CoreFoundation/CoreFoundation.h>
-#include "SDMMobileDevice.h"
+#include <SDMMobileDevice/SDMMobileDevice.h>
 
 enum SpringboardIconType {
 	SpringboardIconTypeInvalid = 0x0,

--- a/iosdeploy/iosdeploy/main.c
+++ b/iosdeploy/iosdeploy/main.c
@@ -8,7 +8,7 @@
 
 #include <getopt.h>
 #include <CoreFoundation/CoreFoundation.h>
-#include "SDMMobileDevice.h"
+#include <SDMMobileDevice/SDMMobileDevice.h>
 #include "attach.h"
 #include "list.h"
 #include "dev.h"

--- a/usbmuxd/usbmuxd/usbmuxd.h
+++ b/usbmuxd/usbmuxd/usbmuxd.h
@@ -10,7 +10,7 @@
 #define usbmuxd_usbmuxd_h
 
 #include <CoreFoundation/CoreFoundation.h>
-#include "Core.h"
+#include <SDMMobileDevice/Core.h>
 
 struct USBMuxPacketBody {
 	uint32_t length;


### PR DESCRIPTION
Heya,

I have made the following changes:
1. Have the 'executable producing projects' treat SDDMobileDevice as an 'external framework project they depend on'  (So now, if you build iosdeploy or iOSConsole, it will first build SDDMobileDevice)
2. Made sure the projects can all compile as well as execute "out of the box" (as in no need to specify build target folder, framework search paths and/or copy the framework into a special folder). Tested on two separate machines using different project file locations to make sure any hard-coded paths are gone.
3. Separated SDDMobileDevice framework code from those who use it (now only 'link' against the framework, rather than compile parts of its code)
4. Clients now treat the header files as coming from an external framework (as in #include <SDMMobileDevice/SDMMobileDevice.h>)

Hope it makes sense :)

Cheers!
Doron Adler
