### PR TITLE
Fix packet receive overwriting (and leaking) the payload of the previous send

### DIFF
--- a/Framework/MobileDevice/Device Listener/SDMMD_USBMuxListener.h
+++ b/Framework/MobileDevice/Device Listener/SDMMD_USBMuxListener.h
@@ -42,6 +42,7 @@ sdmmd_return_t SDMMD_USBMuxConnectByPort(SDMMD_AMDeviceRef device, uint32_t port
 SDMMD_USBMuxListenerRef SDMMD_USBMuxCreate();
 void SDMMD_USBMuxStartListener(SDMMD_USBMuxListenerRef *listener);
 
+struct USBMuxPacket * SDMMD_USBMuxCreatePacketEmpty(void);
 struct USBMuxPacket * SDMMD_USBMuxCreatePacketType(SDMMD_USBMuxPacketMessageType type, CFDictionaryRef payload);
 void USBMuxPacketRelease(struct USBMuxPacket *packet);
 


### PR DESCRIPTION
Release "connect" packet after sending and create new empty packet for response to prevent leak of packet payload dict when SDMMD_USBMuxReceive overwrites the original object.
Added function SDMMD_USBMuxCreatePacketEmpty.
