### PR TITLE
Make sure CFRuntime.h doesn't get included via <SDMMobileDevice/SDMMobileDevice.h>

### DIFF
--- a/Framework/MobileDevice/Connection/SDMMD_Connection_Class.h
+++ b/Framework/MobileDevice/Connection/SDMMD_Connection_Class.h
@@ -29,7 +29,6 @@
 #define _SDM_MD_CONNECTION_CLASS_H_
 
 #include <CoreFoundation/CoreFoundation.h>
-#include <SDMMobileDevice/CFRuntime.h>
 
 /* Classes */
 typedef struct am_connection* SDMMD_AMConnectionRef;

--- a/Framework/MobileDevice/Device Listener/SDMMD_USBMuxListener_Class.h
+++ b/Framework/MobileDevice/Device Listener/SDMMD_USBMuxListener_Class.h
@@ -29,7 +29,6 @@
 #define _SDM_MD_USBMUXLISTENER_CLASS_H_
 
 #include <CoreFoundation/CoreFoundation.h>
-#include <SDMMobileDevice/CFRuntime.h>
 
 typedef struct USBMuxListenerClass * SDMMD_USBMuxListenerRef;
 

--- a/Framework/MobileDevice/Manager/SDMMD_MCP_Class.h
+++ b/Framework/MobileDevice/Manager/SDMMD_MCP_Class.h
@@ -29,7 +29,6 @@
 #define _SDM_MD_MCP_CLASS_H_
 
 #include <CoreFoundation/CoreFoundation.h>
-#include <SDMMobileDevice/CFRuntime.h>
 
 typedef struct sdm_mobiledevice* SDMMobileDeviceRef;
 

--- a/Framework/MobileDevice/Services/AFC/SDMMD_AFCConnection_Class.h
+++ b/Framework/MobileDevice/Services/AFC/SDMMD_AFCConnection_Class.h
@@ -29,7 +29,6 @@
 #define _SDM_MD_AFCCONNECTION_CLASS_H_
 
 #include <CoreFoundation/CoreFoundation.h>
-#include "CFRuntime.h"
 #include "SDMMD_Connection_Class.h"
 
 typedef struct sdmmd_AFCConnectionClass* SDMMD_AFCConnectionRef;

--- a/Framework/MobileDevice/Services/AFC/SDMMD_AFCOperation_Class.h
+++ b/Framework/MobileDevice/Services/AFC/SDMMD_AFCOperation_Class.h
@@ -29,7 +29,6 @@
 #define _SDM_MD_AFCOPERATION_CLASS_H_
 
 #include <CoreFoundation/CoreFoundation.h>
-#include "CFRuntime.h"
 
 typedef struct sdmmd_AFCOperation* SDMMD_AFCOperationRef;
 


### PR DESCRIPTION
Removed inclusion of CFRuntime header from class headers that get brought in via #include <SDMMobileDevice/SDMMobileDevice.h> (CFRuntime.h is already included in the "Internal" headers so these includes were unnecessary)
