### PR TITLE
Make sure SSL error queue is cleared before using SSL functions and checking for errors

### DIFF
--- a/Framework/MobileDevice/Device Types/AMDevice/SDMMD_AMDevice.c
+++ b/Framework/MobileDevice/Device Types/AMDevice/SDMMD_AMDevice.c
@@ -190,6 +190,8 @@ SSL* SDMMD_lockssl_handshake(uint64_t socket, CFTypeRef hostCert, CFTypeRef devi
 						SSL_set_verify_depth(ssl, 0);
 						SSL_set_bio(ssl, bioSocket, bioSocket);
 						SSL_set_ex_data(ssl, (uint32_t)SDMMobileDevice->ivars.peer_certificate_data_index, (void*)deviceCert);
+						
+						ERR_clear_error();
 						result = SSL_do_handshake(ssl);
 						if (result == 1) {
 							SSL_CTX_free(sslCTX);

--- a/Framework/MobileDevice/Services/SDMMD_Service.c
+++ b/Framework/MobileDevice/Services/SDMMD_Service.c
@@ -36,6 +36,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/select.h>
+#include <openssl/err.h>
 #include "Core.h"
 
 #define kMilliseconds 1000
@@ -155,6 +156,7 @@ size_t SDMMD__ServiceReceiveBytesSSL(SocketConnection handle, void * buffer, int
 	
 	do {
 		// Try to read up to length
+		ERR_clear_error();
 		received = SSL_read(handle.socket.ssl, &buffer[receivedTotal], length - receivedTotal);
 		if (received <= 0) {
 			// Read failed, check if theres an SSL error


### PR DESCRIPTION
See http://stackoverflow.com/questions/18179128 and https://www.arangodb.com/2014/07/08
Implemented this to fix a couple obscure errors and crashing I encountered when performing simultaneous requests on multiple devices (20+) over a large USB hub where connections would occasionally die spontaneously
