### PR TITLE
Fixed SDMMD_AMDErrorString returning NULL for ANY error code that isn't a runtime-generated error code.

### DIFF
--- a/Framework/MobileDevice/Error/SDMMD_Error.h
+++ b/Framework/MobileDevice/Error/SDMMD_Error.h
@@ -343,9 +343,8 @@ __attribute__ ((unused)) static char*  SDMMD_AMDErrorString(kern_return_t error)
 		return SDMMD_NewErrorLookup[check];
 	}
 	else {
-		return NULL;
+		return SDMMD_ServiceConnectionErrorString[index];
 	}
-	return SDMMD_ServiceConnectionErrorString[index];
 }
 
 static char* SDMMD_AFCConnectionErrorString[0x18] = {"kAFCSuccess", "kAFCUndefinedError", "kAFCBadHeaderError", "kAFCNoResourcesError", "kAFCReadError", "kAFCWriteError", "kAFCUnknownPacketError", "kAFCInvalidArgumentError", "kAFCNotFoundError", "kAFCIsDirectoryError", "kAFCPermissionError", "kAFCNotConnectedError", "kAFCTimeOutError", "kAFCOverrunError", "kAFCEOFError", "kAFCUnsupportedError", "kAFCFileExistsError", "kAFCBusyError", "kAFCNoSpaceError", "kAFCWouldBlockError", "kAFCInputOutputError", "kAFCInterruptedError", "kAFCInProgressError", "kAFCInternalError"};


### PR DESCRIPTION
I assume that's an oversight
