### PR TITLE
Device install and launch support.

### DIFF
--- a/iOSConsole/iOSConsole/dev.c
+++ b/iOSConsole/iOSConsole/dev.c
@@ -22,7 +22,8 @@
 #define PREP_CMDS_PATH "/tmp/sdmmd-lldb-prep"
 
 #define LLDB_PREP_CMDS CFSTR("\
-target modules search-paths add /usr \"{SYMBOLS_PATH}/usr\" /System \"{SYMBOLS_PATH}/System\" \"{CONTAINER_PATH}\" \"{DISK_CONTAINER}\" \"{CONTAINER_PATH}\" \"{DISK_CONTAINER}\" /Developer \"{SYMBOLS_PATH}/Developer\"\n\
+platform select remote-ios \n\
+target create \"{APP_PATH}\"\n\
 ")
 
 void SetupDeviceForDevelopment(char *udid)
@@ -223,7 +224,7 @@ void StartDebuggingAndDetach(char *udid, char *app_path)
 		pid_t parent = getpid();
 		int pid = fork();
 		if (pid == 0) {
-			system("xcrun -sdk iphoneos lldb /tmp/sdmmd-lldb-prep");
+			execl("xcrun", "-sdk", "iphoneos", "lldb", "-s", "/tmp/sdmmd-lldb-prep");
 			kill(parent, SIGHUP);
 			_exit(0);
 		}

--- a/iOSConsole/iOSConsole/main.c
+++ b/iOSConsole/iOSConsole/main.c
@@ -86,7 +86,7 @@ int main(int argc, const char *argv[])
 	int c;
 	while (searchArgs) {
 		int option_index = 0x0;
-		c = getopt_long(argc, (char *const *)argv, "lh:d:ais:q:p:t:c:z", long_options, &option_index);
+		c = getopt_long(argc, (char *const *)argv, "lh:d:ais:q:r:p:t:c:z", long_options, &option_index);
 		if (c == -1) {
 			break;
 		}
@@ -246,7 +246,7 @@ int main(int argc, const char *argv[])
 			PerformQuery(udid, domain, key);
 		}
 		else if (optionsEnable[OptionsRun]) {
-			RunAppOnDeviceWithIdentifier(udid, bundle);
+			RunAppOnDeviceWithIdentifier(udid, bundle, false);
 		}
 		else if (optionsEnable[OptionsDiag]) {
 			if (diagArg) {

--- a/iOSConsole/iOSConsole/run.h
+++ b/iOSConsole/iOSConsole/run.h
@@ -9,6 +9,6 @@
 #ifndef iOSConsole_run_h
 #define iOSConsole_run_h
 
-void RunAppOnDeviceWithIdentifier(char *udid, char *identifier);
+void RunAppOnDeviceWithIdentifier(char *udid, char *identifier, bool waitForDebugger);
 
 #endif


### PR DESCRIPTION
This fixes some bugs in launching the installed program with `iOSConsole` (issue #77).  You should be able to do

```
iOSConsole -d UDID -r bundleID [-w]
```

to wait for the debugger to attach, or omit the -w to launch immediately and come back.